### PR TITLE
Use registry with container and don't use container.has; fixes #19

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -5,12 +5,11 @@ export default Ember.Mixin.create({
     this._super(...arguments);
 
     const stateName = 'state:' + this.stateName;
+    const StateFactory = this.container.lookupFactory(stateName);
 
-    if (!this.container.has(stateName)) {
+    if (StateFactory === undefined) {
       throw new TypeError('Unknown StateFactory: `' + stateName + '`');
     }
-
-    const StateFactory = this.container.lookupFactory(stateName);
 
     this.states = new Ember.MapWithDefault({
       defaultValue: key => this.setupState(StateFactory, key)

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-state-services",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.10.0",
+    "ember": "1.11.1",
     "ember-resolver": "~0.1.12",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "ember-cli": "0.2.0",
+    "ember-cli": "0.2.3",
     "ember-cli-app-version": "0.3.2",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.8",

--- a/tests/unit/state-mixin-test.js
+++ b/tests/unit/state-mixin-test.js
@@ -4,14 +4,16 @@ import StateMixin from 'ember-state-services/mixin';
 
 let State;
 let Service;
+let registry;
 let container;
 let subject;
 
 module('State Mixin', {
   setup: function() {
-    container = new Ember.Container();
+    registry = new Ember.Registry();
+    container = new Ember.Container(registry);
 
-    container.register('state:test-state', Ember.Object.extend({}), {
+    registry.register('state:test-state', Ember.Object.extend({}), {
         singleton:   true,
         instantiate: false
     });
@@ -103,4 +105,17 @@ test('teardownStateFor properly clears a state for a key', function(assert) {
 
   assert.equal(subject.get('state.firstName'), undefined);
   assert.ok(!subject.service.hasStateFor('person2'));
+});
+
+test('Creating a state service with an unknown StateFactory throws error', function(assert) {
+  assert.expect(1);
+  
+  Service = Ember.Service.extend(StateMixin, {
+    stateName: 'test-state-that-does-not-exist',
+    container: container
+  });
+
+  assert.throws(function() {
+    Service.create();
+  }, TypeError, 'Unknown StateFactory: `test-state-that-does-not-exist`');
 });


### PR DESCRIPTION
Fixes #19

Cc/ @stefanpenner 

`container.has` is deprecated: https://github.com/emberjs/ember.js/commit/e5148e63ae2f507fc9912fca9c154fc8e84fe18d

`Ember.Registry` must be used when creating a container: https://github.com/emberjs/ember.js/pull/10038