### PR TITLE
specify stateName value with a dash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import Ember from 'ember';
 import StateMixin from 'ember-state-services/mixin'
 
 export default Ember.Object.extend(StateMixin, {
-  stateName: 'emailEdit'
+  stateName: 'email-edit'
 });
 ```
 


### PR DESCRIPTION
This is how I needed to register the state in order to get a simple test to run.

```js
import { moduleFor, test } from 'ember-qunit';

moduleFor('service:email-edit', 'EmailEditService', {
	needs: ['state:email-edit'],
});

// Replace this with your real tests.
test('it works', function(assert) {
	var service = this.subject();
	assert.ok(service);
});
```