### PR TITLE
New stateFor CP

### DIFF
--- a/addon/state-for.js
+++ b/addon/state-for.js
@@ -5,73 +5,38 @@ var {
   assert
 } = Ember;
 
-var stateHashMap = {};
+var states = {};
 
-/*
-*
-*/
-function stateFactoryLookup(container, stateName) {
-  let stateContainerName = `state:${stateName}`;
-  let StateFactory = container.lookupFactory(stateContainerName);
+function createState(container, stateName) {
+  const stateContainerName = `state:${stateName}`;
+  const StateFactory = container.lookupFactory(stateContainerName);
 
   if (StateFactory === undefined) {
     throw new TypeError('Unknown StateFactory: `' + stateContainerName + '`');
   }
 
-  return StateFactory;
+  states[stateName] = new Ember.MapWithDefault({
+    defaultValue: key => setupState(StateFactory, key)
+  });
+
+  return states;
 }
 
-/*
-*
-*/
-function stateFromCache(stateName, keyValue) {
-  let stateCache = stateHashMap[stateName];
-
-  if (stateCache && stateCache[keyValue]) {
-    return stateCache[keyValue];
-  }
+function setupState(Factory, model) {
+  return Factory.create({
+    content: model
+  });
 }
-
-/*
-*
-*/
-function addStateToCache(stateName, keyValue, state) {
-
-  if (stateHashMap[stateName] && stateHashMap[stateName][keyValue]) {
-    throw new Error(`${keyValue} is no unqiue and has collided with another state.`);
-  }
-
-  if (stateHashMap[stateName]) {
-    stateHashMap[stateName][keyValue] = state;
-    return state;
-  }
-
-  stateHashMap[stateName] = {
-    [keyValue]: state
-  };
-
-  return state;
-}
-
 
 export default function(stateName, options) {
   assert('key property must be passed in via the second parameter', options.key);
 
   return computed(options.key, function() {
-    debugger;
-
-    let stateCache = stateFromCache(stateName, this.get(options.key));
-
-    if (stateCache) {
-      return stateCache;
+    if (states[stateName]) {
+      return states[stateName].get(this.get(options.key));
     }
 
-    let stateFactory = stateFactoryLookup(this.container, stateName);
-    let state = stateFactory.create();
-
-    addStateToCache(stateName, this.get(options.key), state);
-
-    return state;
+    createState(this.container, stateName);
+    return states[stateName].get(this.get(options.key));
   });
-
 }

--- a/addon/state-for.js
+++ b/addon/state-for.js
@@ -2,41 +2,79 @@ import Ember from 'ember';
 
 var {
   computed,
-  assert
+  assert,
+  typeOf
 } = Ember;
 
 var states = {};
 
-function createState(container, stateName) {
-  const stateContainerName = `state:${stateName}`;
-  const StateFactory = container.lookupFactory(stateContainerName);
+/*
+* Create the states object for a given stateName.
+*
+* @param container {object} container to lookup the state factory on
+* @param stateName {string} state name which is also the name of the factory
+*/
+function createStates(container, stateName) {
+  let stateContainerName = `state:${stateName}`;
+  let StateFactory       = container.lookupFactory(stateContainerName);
 
-  if (StateFactory === undefined) {
-    throw new TypeError('Unknown StateFactory: `' + stateContainerName + '`');
+  if (!StateFactory) {
+    throw new TypeError(`Unknown StateFactory: \`${stateContainerName}\``);
   }
 
   states[stateName] = new Ember.MapWithDefault({
-    defaultValue: key => setupState(StateFactory, key)
+    defaultValue: () => buildDefaultState.call(this, StateFactory)
   });
 
-  return states;
+  return states[stateName];
 }
 
-function setupState(Factory, model) {
-  return Factory.create({
-    content: model
-  });
+/*
+* When creating the state instance we use `initialState` method
+* on the state class to build its initial state. If it not
+* specified then {} is used as the default state.
+*
+* @param Factory {StateFactoryClass} state factory from the container
+* @return {stateInstance} state instance object from the factory
+*/
+function buildDefaultState(Factory) {
+  let defaultState = {};
+
+  if (typeOf(Factory.initialState) === 'function') {
+    defaultState = Factory.initialState.call(this);
+  }
+
+  return Factory.create(defaultState);
 }
 
-export default function(stateName, options) {
-  assert('key property must be passed in via the second parameter', options.key);
+/*
+* Returns a computed property that returns state based off of a dynamic key.
+*
+* @param stateName {string} name of the state factory which is located in /states/<stateName>.js
+* @param options {object}
+* @param {string} options.key - required - the dynamic state key
+* @param {object} options.container - optional - container reference
+* @return {computed property}
+*/
+export default function stateFor(stateName, options) {
+  var { key, container } = options;
 
-  return computed(options.key, function() {
+  assert(`
+    Missing \`key\` property within the second argument. You passed: ${JSON.stringify(options)}
+    `, key);
+
+  return computed(key, function() {
+    assert(`
+      Could not find the container on \`this\` or passed in via:
+      stateFor('${stateName}', { key: ${key}, container: <pass container here> })
+      `, this.container || container);
+
     if (states[stateName]) {
-      return states[stateName].get(this.get(options.key));
+      return states[stateName].get(this.get(key));
     }
 
-    createState(this.container, stateName);
-    return states[stateName].get(this.get(options.key));
+    return createStates
+              .apply(this, [container || this.container, stateName])
+              .get(this.get(key));
   });
 }

--- a/addon/state-for.js
+++ b/addon/state-for.js
@@ -1,0 +1,77 @@
+import Ember from 'ember';
+
+var {
+  computed,
+  assert
+} = Ember;
+
+var stateHashMap = {};
+
+/*
+*
+*/
+function stateFactoryLookup(container, stateName) {
+  let stateContainerName = `state:${stateName}`;
+  let StateFactory = container.lookupFactory(stateContainerName);
+
+  if (StateFactory === undefined) {
+    throw new TypeError('Unknown StateFactory: `' + stateContainerName + '`');
+  }
+
+  return StateFactory;
+}
+
+/*
+*
+*/
+function stateFromCache(stateName, keyValue) {
+  let stateCache = stateHashMap[stateName];
+
+  if (stateCache && stateCache[keyValue]) {
+    return stateCache[keyValue];
+  }
+}
+
+/*
+*
+*/
+function addStateToCache(stateName, keyValue, state) {
+
+  if (stateHashMap[stateName] && stateHashMap[stateName][keyValue]) {
+    throw new Error(`${keyValue} is no unqiue and has collided with another state.`);
+  }
+
+  if (stateHashMap[stateName]) {
+    stateHashMap[stateName][keyValue] = state;
+    return state;
+  }
+
+  stateHashMap[stateName] = {
+    [keyValue]: state
+  };
+
+  return state;
+}
+
+
+export default function(stateName, options) {
+  assert('key property must be passed in via the second parameter', options.key);
+
+  return computed(options.key, function() {
+    debugger;
+
+    let stateCache = stateFromCache(stateName, this.get(options.key));
+
+    if (stateCache) {
+      return stateCache;
+    }
+
+    let stateFactory = stateFactoryLookup(this.container, stateName);
+    let state = stateFactory.create();
+
+    addStateToCache(stateName, this.get(options.key), state);
+
+    return state;
+  });
+
+}

--- a/tests/dummy/app/components/edit-email.js
+++ b/tests/dummy/app/components/edit-email.js
@@ -3,7 +3,7 @@ import stateFor from 'ember-state-services/state-for';
 
 export default Ember.Component.extend({
   tagName: 'form',
-  data: stateFor('edit-email', { key: 'email.id' }),
+  data: stateFor('edit-email', { key: 'email' }),
 
   actions: {
     save: function() {

--- a/tests/dummy/app/components/edit-email.js
+++ b/tests/dummy/app/components/edit-email.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
+import stateFor from 'ember-state-services/state-for';
 
 export default Ember.Component.extend({
   tagName: 'form',
-  editEmailService: Ember.inject.service('edit-email'),
-  data: Ember.computed('email', function() {
-    return this.get('editEmailService').stateFor(this.get('email'));
-  }).readOnly(),
+  data: stateFor('edit-email', { key: 'email.id' }),
 
   actions: {
     save: function() {

--- a/tests/dummy/app/states/edit-email.js
+++ b/tests/dummy/app/states/edit-email.js
@@ -1,3 +1,9 @@
 import BufferedProxy from 'ember-buffered-proxy/proxy';
 
+BufferedProxy.reopenClass({
+  initialState() {
+    return { content: this.get('email') };
+  }
+});
+
 export default BufferedProxy.extend();


### PR DESCRIPTION
Solves: #28 

This gives the following syntax:

```js
import Ember from 'ember';
import stateFor from 'ember-state-services/stateFor';

export default Ember.Component.extend({
  data: stateFor('state-name', { key: 'state-key' })
});
```

@stefanpenner I need to talk with you about how we should handle "default" state. Before this was done inside of the users own service file (inside setupState override) but now this is done behind the scenes.