### PR TITLE
Add failing test for #42

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,8 @@
 {
   "name": "ember-state-services",
   "dependencies": {
-    "ember": "2.0.1",
+    "ember": "2.1.0",
+    "ember-data": "2.1.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
@@ -13,6 +14,6 @@
     "qunit": "~1.18.0"
   },
   "resolutions": {
-    "ember": "2.0.1"
+    "ember": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
+    "ember-data": "2.1.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr()
+});

--- a/tests/unit/ember-data-test.js
+++ b/tests/unit/ember-data-test.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+import { test, moduleForModel } from 'ember-qunit';
+import stateFor from 'ember-state-services/state-for';
+
+let registry  = new Ember.Registry();
+let container = new Ember.Container(registry);
+let mockStatePOJO = { sample: 'example' };
+const registryOpts = { singleton: true, instantiate: false };
+
+moduleForModel('user', {
+  // needs: []
+  beforeEach() {
+    this.registry.register('state:test-state-pojo', mockStatePOJO, registryOpts);
+  }
+});
+
+test('that the key value can be an EmberData model', function(assert) {
+  var modelA = this.subject({
+    name: 'Bobby'
+  });
+  var modelB = this.subject({
+    name: 'Lisa'
+  });
+  let mockObject = Ember.Object.extend({
+    data: stateFor('test-state-pojo', 'model')
+  }).create({
+    container: this.container,
+    model: modelA
+  });
+
+  assert.expect(3);
+  assert.equal(mockObject.get('data.sample'), 'example');
+  mockObject.set('data.sample', 'foo-bar');
+  mockObject.set('model', modelB);
+  assert.equal(mockObject.get('data.sample'), 'example');
+  mockObject.set('model', modelA);
+  assert.equal(mockObject.get('data.sample'), 'foo-bar');
+});

--- a/tests/unit/ember-data-test.js
+++ b/tests/unit/ember-data-test.js
@@ -2,8 +2,6 @@ import Ember from 'ember';
 import { test, moduleForModel } from 'ember-qunit';
 import stateFor from 'ember-state-services/state-for';
 
-let registry  = new Ember.Registry();
-let container = new Ember.Container(registry);
 let mockStatePOJO = { sample: 'example' };
 const registryOpts = { singleton: true, instantiate: false };
 
@@ -15,12 +13,18 @@ moduleForModel('user', {
 });
 
 test('that the key value can be an EmberData model', function(assert) {
-  var modelA = this.subject({
-    name: 'Bobby'
+  var store = this.store();
+  var modelA, modelB;
+
+  Ember.run(() => {
+    modelA = store.createRecord('user', {
+      name: 'Bobby'
+    });
+    modelB = store.createRecord('user', {
+      name: 'Lisa'
+    });
   });
-  var modelB = this.subject({
-    name: 'Lisa'
-  });
+
   let mockObject = Ember.Object.extend({
     data: stateFor('test-state-pojo', 'model')
   }).create({


### PR DESCRIPTION
Basically tests that Ember Data models can be used as keys
for state (which they cannot at the moment, see #42).

This is a failing test, so travis should fail.