### PR TITLE
Use getOwner directly from Ember to avoid getOwner import deprecation

### DIFF
--- a/addon/state-for.js
+++ b/addon/state-for.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import WeakMap from 'ember-weakmap/weak-map';
-import getOwner from 'ember-getowner-polyfill';
 
 let {
   computed,
-  assert
+  assert,
+  getOwner
 } = Ember;
 
 /*

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "ember-weakmap": "0.4.0",
-    "ember-getowner-polyfill": "^1.0.0",
+    "ember-getowner-polyfill": "^1.1.1",
     "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {


### PR DESCRIPTION
- use `getOwner` directly from Ember to avoid getOwner import deprecation
- fix tests to use new owner for Ember versions 2.3 and above
- bump `ember-getowner-polyfill` version