### PR TITLE
fix: Create weakmap before returning weakmap

### DIFF
--- a/addon/state-for.js
+++ b/addon/state-for.js
@@ -24,11 +24,11 @@ let weakMaps = {};
 * stateFor('state-name').get(this.get('property-name'));
 */
 export default function stateFor(stateName, propertyName) {
-  if (!weakMaps[stateName]) {
-    weakMaps[stateName] = new WeakMap();
-  }
-
   let state = weakMaps[stateName];
+
+  if (state === undefined) {
+    state = weakMaps[stateName] = new WeakMap();
+  }
 
   if (arguments.length === 1) {
     return state;

--- a/addon/state-for.js
+++ b/addon/state-for.js
@@ -24,8 +24,14 @@ let weakMaps = {};
 * stateFor('state-name').get(this.get('property-name'));
 */
 export default function stateFor(stateName, propertyName) {
+  if (!weakMaps[stateName]) {
+    weakMaps[stateName] = new WeakMap();
+  }
+
+  let state = weakMaps[stateName];
+
   if (arguments.length === 1) {
-    return weakMaps[stateName];
+    return state;
   }
 
   assert('The second argument must be a string', typeof propertyName === 'string');
@@ -41,12 +47,6 @@ export default function stateFor(stateName, propertyName) {
     if (typeof propertyValue !== 'object' && typeof propertyValue !== 'function') {
       throw new TypeError('The state key must resolve to a non primitive value');
     }
-
-    if (!weakMaps[stateName]) {
-      weakMaps[stateName] = new WeakMap();
-    }
-
-    let state = weakMaps[stateName];
 
     if (!state.has(propertyValue)) {
       let newState = createStateFor(this, stateName, getOwner(this));

--- a/tests/unit/state-service-test.js
+++ b/tests/unit/state-service-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { module, test } from 'ember-qunit';
 import stateFor from 'ember-state-services/state-for';
+import WeakMap from 'ember-weakmap/weak-map';
 
 let registry;
 let container;
@@ -66,6 +67,13 @@ module('State Mixin', {
       data: stateFor('test-state', 'model')
     });
   }
+});
+
+test('that stateFor with a single param returns the map before being accessed first', function(assert) {
+  assert.expect(1);
+  
+  let map = stateFor('test-state');
+  assert.ok(map instanceof WeakMap);
 });
 
 test('that the state factory creates the correct object', function(assert) {

--- a/tests/unit/state-service-test.js
+++ b/tests/unit/state-service-test.js
@@ -73,7 +73,21 @@ test('that stateFor with a single param returns the map before being accessed fi
   assert.expect(1);
   
   let map = stateFor('test-state');
+
   assert.ok(map instanceof WeakMap);
+});
+
+test('that stateFor with a single param returns the map which is initially unpopulated', function(assert) {
+  assert.expect(3);
+  
+  let map = stateFor('test-state');
+
+  assert.notOk(map.get(mockModelA));
+
+  let data = subject.get('data');
+
+  assert.equal(data.bar, 'foo');
+  assert.equal(map.get(mockModelA).bar, 'foo');
 });
 
 test('that the state factory creates the correct object', function(assert) {

--- a/tests/unit/state-service-test.js
+++ b/tests/unit/state-service-test.js
@@ -87,7 +87,7 @@ test('that stateFor with a single param returns the map which is initially unpop
   let data = subject.get('data');
 
   assert.equal(data.bar, 'foo');
-  assert.equal(map.get(mockModelA).bar, 'foo');
+  assert.equal(map.get(mockModelA), data);
 });
 
 test('that the state factory creates the correct object', function(assert) {


### PR DESCRIPTION
Previously `state: stateFor('some-state')` would return `undefined` if used in a route, before the computed property was called. This change fixes that.