### PR TITLE
add dev-dependency of ember-buffered-proxy

### DIFF
--- a/blueprints/ember-state-services/index.js
+++ b/blueprints/ember-state-services/index.js
@@ -2,6 +2,6 @@ module.exports = {
   normalizeEntityName: function() {}, // no-op since we're just adding dependencies
 
   afterInstall: function() {
-    return this.addAddonToProject('ember-buffered-proxy', '^0.6.0');
+    return this.addAddonToProject('ember-buffered-proxy', '^0.7.0');
   }
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
+    "ember-buffered-proxy": "^0.7.0",
     "ember-cli": "2.12.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,6 +1750,12 @@ ember-ajax@^2.4.1:
   dependencies:
     ember-cli-babel "^5.1.5"
 
+ember-buffered-proxy@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/ember-buffered-proxy/-/ember-buffered-proxy-0.7.0.tgz#966c1cab8906247b0d9c358465cca7d83badbf71"
+  dependencies:
+    ember-cli-babel "^5.1.7"
+
 ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7, ember-cli-babel@^5.2.1:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"


### PR DESCRIPTION
`ember server` currently would fail import due to `ember-buffered-proxy` wasn't installed.