### PR TITLE
Inject the owner context into the state

### DIFF
--- a/addon/state-for.js
+++ b/addon/state-for.js
@@ -79,18 +79,11 @@ function createStateFor(context, stateName, owner) {
   }
 
   if (EmberObject.detect(StateFactoryClass)) {
-    return createClassInstance(StateFactoryClass, defaultState, owner);
+    return StateFactoryClass.create(
+      owner.ownerInjection(),
+      defaultState
+    );
   }
 
-  return createClassInstance(EmberObject, StateFactoryClass, owner);
-}
-
-function createClassInstance(cls, props, owner) {
-  if (typeof owner.ownerInjection === 'function') {
-    // ember >= 2.3.0
-    return cls.create(owner.ownerInjection(), props)
-  }
-
-  // ember < 2.3.0
-  return cls.extend({ container: owner.__container__ }).create(props)
+  return EmberObject.create(owner.ownerInjection(), StateFactoryClass);
 }

--- a/addon/state-for.js
+++ b/addon/state-for.js
@@ -79,8 +79,18 @@ function createStateFor(context, stateName, owner) {
   }
 
   if (EmberObject.detect(StateFactoryClass)) {
-    return StateFactoryClass.create(defaultState);
+    return createClassInstance(StateFactoryClass, defaultState, owner);
   }
 
-  return EmberObject.create(StateFactoryClass);
+  return createClassInstance(EmberObject, StateFactoryClass, owner);
+}
+
+function createClassInstance(cls, props, owner) {
+  if (typeof owner.ownerInjection === 'function') {
+    // ember >= 2.3.0
+    return cls.create(owner.ownerInjection(), props)
+  }
+
+  // ember < 2.3.0
+  return cls.extend({ container: owner.__container__ }).create(props)
 }


### PR DESCRIPTION
We use this addon in combination with `ember-cp-validations` which needs the owner context. For this reason I injected the container when creating the state class.