### PR TITLE
fix: update ember-cli-babel to 6.14+

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.3.0",
+    "ember-cli-babel": "^6.14.0",
     "ember-weakmap": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This removes the deprecation warning. Would love to see this released asap 👍 